### PR TITLE
Change country and city types to be strings

### DIFF
--- a/pallet-smart-contract/src/tests.rs
+++ b/pallet-smart-contract/src/tests.rs
@@ -280,7 +280,7 @@ fn prepare_farm_and_node() {
 		bob()
 	).unwrap();
 
-	TfgridModule::create_farm(Origin::signed(alice()), farm_name.as_bytes().to_vec(), pallet_tfgrid_types::CertificationType::Diy, 0, 0, pub_ips.clone()).unwrap();
+	TfgridModule::create_farm(Origin::signed(alice()), farm_name.as_bytes().to_vec(), pub_ips.clone()).unwrap();
 
 	// random location
 	let location = pallet_tfgrid_types::Location{
@@ -295,7 +295,9 @@ fn prepare_farm_and_node() {
 		mru: 1,
 	};
 
-	TfgridModule::create_node(Origin::signed(alice()), 1, resources, location, 0, 0, None).unwrap();
+	let country = "Belgium".as_bytes().to_vec();
+	let city = "Ghent".as_bytes().to_vec();
+	TfgridModule::create_node(Origin::signed(alice()), 1, resources, location, country, city, None).unwrap();
 }
 
 fn run_to_block(n: u64) {

--- a/pallet-tfgrid/src/mock.rs
+++ b/pallet-tfgrid/src/mock.rs
@@ -132,14 +132,14 @@ pub fn bob() -> AccountId {
 	get_account_id_from_seed::<sr25519::Public>("Bob")
 }
 
-pub fn sign_create_entity(name: Vec<u8>, country_id: u32, city_id: u32) -> Vec<u8> {
+pub fn sign_create_entity(name: Vec<u8>, country: Vec<u8>, city: Vec<u8>) -> Vec<u8> {
 	let seed = hex::decode("59336423ee7af732b2d4a76e440651e33e5ba51540e5633535b9030492c2a6f6").unwrap();
 	let pair = ed25519::Pair::from_seed_slice(&seed).unwrap();
 
 	let mut message = vec![];
 	message.extend_from_slice(&name);
-	message.extend_from_slice(&country_id.to_be_bytes());
-	message.extend_from_slice(&city_id.to_be_bytes());
+	message.extend_from_slice(&country);
+	message.extend_from_slice(&city);
 
 	let signature = pair.sign(&message);
 

--- a/pallet-tfgrid/src/types.rs
+++ b/pallet-tfgrid/src/types.rs
@@ -7,8 +7,8 @@ pub struct Entity<AccountId> {
     pub id: u32,
     pub name: Vec<u8>,
     pub account_id: AccountId,
-    pub country_id: u32,
-    pub city_id: u32,
+    pub country: Vec<u8>,
+    pub city: Vec<u8>,
 }
 
 //digital twin
@@ -32,8 +32,6 @@ pub struct Farm {
     pub twin_id: u32,
     pub pricing_policy_id: u32,
     pub certification_type: CertificationType,
-    pub country_id: u32,
-    pub city_id: u32,
     pub public_ips: Vec<PublicIP>
 }
 
@@ -45,8 +43,8 @@ pub struct Node {
     pub twin_id: u32,
     pub resources: Resources,
     pub location: Location,
-    pub country_id: u32,
-    pub city_id: u32,
+    pub country: Vec<u8>,
+    pub city: Vec<u8>,
     // optional public config
     pub public_config: Option<PublicConfig>,
     pub uptime: u64,


### PR DESCRIPTION
For country values we can now use the standard ISO 3166-1 2-letter or 3-letter country code
And for city values we can use whatever is returned from https://geoip.grid.tf/

We also removed storing these values on Farms because it does not really makes sense to have a location on a Farm